### PR TITLE
Use kubecfg wrapper in ksonnet_to_yaml rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,4 +5,5 @@ sh_binary(
         "@ksonnet_lib//:files",
         "@kubecfg//:kubecfg",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/ksonnet.bzl
+++ b/ksonnet.bzl
@@ -25,6 +25,6 @@ def ksonnet_to_yaml(name, src, out, deps=[]):
             "@ksonnet_lib//:files",
         ] + deps,
         outs = [out],
-        cmd = "$(location @kubecfg//:kubecfg) -J external show -o yaml %s >$@" % src,
-        tools = ["@kubecfg//:kubecfg"],
+        cmd = "$(location @rules_ksonnet//:kubecfg) show -o yaml %s >$@" % src,
+        tools = ["@rules_ksonnet//:kubecfg"],
     )

--- a/kubecfg.sh
+++ b/kubecfg.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-exec external/kubecfg/kubecfg -J external "$@"
+exec ${0}.runfiles/__main__/external/kubecfg/kubecfg -J external "$@"


### PR DESCRIPTION
so that we don't have to duplicate the -J flag